### PR TITLE
[WIP] (failed) attempt at fixing https://github.com/marler8997/har/issues/14

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -3,12 +3,18 @@ description "An extractor/archiver for HAR, the human-readable archive format"
 authors "Jonathan Marler"
 copyright "Copyright © 2018, Jonathan Marler"
 license "BSL-1.0"
-version "0.1.0"
-targetType "executable"
-targetPath "out"
-dependency "har:library" version="*"
-sourceFiles "harmain.d"
-sourcePaths
+targetType "none"
+
+subPackage {
+  name "har"
+  description "An extractor/archiver for HAR, the human-readable archive format"
+  targetType "executable"
+  targetName "har"
+  targetPath "out"
+  sourceFiles "harmain.d"
+  sourcePaths
+  dependency "har:library" version="*"
+}
 
 subPackage {
   name "library"
@@ -24,7 +30,7 @@ subPackage {
   description "Tests the har command line tool"
   targetType "executable"
   targetPath "out/test"
-  dependency "har" version="*"
+  dependency "har:har" version="*"
   sourceFiles "test_command_line_tool.d"
   sourcePaths
 }


### PR DESCRIPTION
attempt at fixing https://github.com/marler8997/har/issues/14

/cc @s-ludwig @MartinNowak
is that a dub bug? doesn't seem to work either

`dub run har:test_command_line_tool` doesn't build `har:har` even though it depends on it
workaround: use 
```
dub run har:har
dub run har:test_command_line_tool
```


```
dub run --force --verbose har:test_command_line_tool
Using dub registry url 'https://code.dlang.org/'
Refreshing local packages (refresh existing: true)...
Looking for local package map at /var/lib/dub/packages/local-packages.json
Looking for local package map at /Users/timothee/.dub/packages/local-packages.json
Try to load local package map at /Users/timothee/.dub/packages/local-packages.json
Determined package version using GIT: har 0.1.0+commit.3.ga421762
Ignoring version specification (>=0.0.0) for path based dependency .
Ignoring version specification (>=0.0.0) for path based dependency .
Ignoring version specification (>=0.0.0) for path based dependency .
Ignoring version specification (>=0.0.0) for path based dependency .
Ignoring version specification (>=0.0.0) for path based dependency .
Ignoring version specification (>=0.0.0) for path based dependency .
Ignoring version specification (>=0.0.0) for path based dependency .
Ignoring version specification (>=0.0.0) for path based dependency .
Ignoring version specification (>=0.0.0) for path based dependency .
Ignoring version specification (>=0.0.0) for path based dependency .
Ignoring version specification (>=0.0.0) for path based dependency .
Ignoring version specification (>=0.0.0) for path based dependency .
Ignoring version specification (>=0.0.0) for path based dependency .
Ignoring version specification (>=0.0.0) for path based dependency .
Ignoring version specification (>=0.0.0) for path based dependency .
Ignoring version specification (>=0.0.0) for path based dependency .
Ignoring version specification (>=0.0.0) for path based dependency .
Ignoring version specification (>=0.0.0) for path based dependency .
Ignoring version specification (>=0.0.0) for path based dependency .
Ignoring version specification (>=0.0.0) for path based dependency .
Ignoring version specification (>=0.0.0) for path based dependency .
Ignoring version specification (>=0.0.0) for path based dependency .
Ignoring version specification (>=0.0.0) for path based dependency .
Ignoring version specification (>=0.0.0) for path based dependency .
Refreshing local packages (refresh existing: false)...
Looking for local package map at /var/lib/dub/packages/local-packages.json
Looking for local package map at /Users/timothee/.dub/packages/local-packages.json
Try to load local package map at /Users/timothee/.dub/packages/local-packages.json
Building package har:test_command_line_tool in /Users/timothee/git_clone/D/har/
Refreshing local packages (refresh existing: false)...
Looking for local package map at /var/lib/dub/packages/local-packages.json
Looking for local package map at /Users/timothee/.dub/packages/local-packages.json
Try to load local package map at /Users/timothee/.dub/packages/local-packages.json
  Found dependency har:har 0.1.0
    Found dependency har:library 0.1.0
Refreshing local packages (refresh existing: false)...
Looking for local package map at /var/lib/dub/packages/local-packages.json
Looking for local package map at /Users/timothee/.dub/packages/local-packages.json
Try to load local package map at /Users/timothee/.dub/packages/local-packages.json
  Found dependency har:har 0.1.0
    Found dependency har:library 0.1.0
Checking for upgrades.
Using cached upgrade results...
Generating using build
Configuring dependent har:test_command_line_tool, deps:
Performing "debug" build using dmd for x86_64.
har:test_command_line_tool 0.1.0: building configuration "application"...
dmd -c -of.dub/build/application-debug-posix.osx-x86_64-dmd_2079-415E6A4DA0BF107779F307A1A4432F92/har_test_command_line_tool.o -debug -g -w -version=Have_har_test_command_line_tool -Isrc/ test_command_line_tool.d -vcolumns
Linking...
dmd -of.dub/build/application-debug-posix.osx-x86_64-dmd_2079-415E6A4DA0BF107779F307A1A4432F92/har_test_command_line_tool .dub/build/application-debug-posix.osx-x86_64-dmd_2079-415E6A4DA0BF107779F307A1A4432F92/har_test_command_line_tool.o -g
Copying target from /Users/timothee/git_clone/D/har/.dub/build/application-debug-posix.osx-x86_64-dmd_2079-415E6A4DA0BF107779F307A1A4432F92/har_test_command_line_tool to /Users/timothee/git_clone/D/har/out/test
Running ./out/test/har_test_command_line_tool
[SHELL] /Users/timothee/git_clone/D/har/out/har /Users/timothee/git_clone/D/har/test/a.har --dir=/Users/timothee/git_clone/D/har/out/test/a.expected
/bin/sh: /Users/timothee/git_clone/D/har/out/har: No such file or directory
--------------------------------------------------------------------------------
last command exited with code 127
Program exited with code 1
```

